### PR TITLE
manifests: don't use default service account

### DIFF
--- a/manifests/cluster_role_binding.yaml
+++ b/manifests/cluster_role_binding.yaml
@@ -12,6 +12,5 @@ roleRef:
   name: observatorium-operator
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: observatorium-operator
   namespace: default
-

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: observatorium-operator
     spec:
+      serviceAccountName: observatorium-operator
       containers:
       - name: observatorium-operator
         image: quay.io/observatorium/observatorium-operator:latest

--- a/manifests/service_account.yaml
+++ b/manifests/service_account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: observatorium-operator
+    app.kubernetes.io/version: v0.1
+  name: observatorium-operator


### PR DESCRIPTION
This commit ensures that the default service account is not used in the
example manifests, as this sets a bad precedent.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @clyang82 @metalmatze 