### PR TITLE
Overwrite the nodeSelector for StatefulSets & Deployments

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -61,5 +61,12 @@ local patchObs = obs {
         uid: config.uid,
       }],
     },
+    spec+: if (v.kind == 'StatefulSet' || v.kind == 'Deployment') then {
+      template+: {
+        spec+:{
+          nodeSelector+: { 'kubernetes.io/os': 'linux' }, // TODO: replace with the nodeSelector from the CustomResource
+        },
+      },
+    } else {},
   }, patchObs.manifests),
 }


### PR DESCRIPTION
This is adding a nodeSelector to every single StatefulSet or Deployment the Operator manages.
Now, you just need to add the nodeSelector from the CustomResource into this place and that's it. All Pods deployed by the operator are going to have that nodeSelector.

No need to change every project underneath. That's why we chose jsonnet in the first place. :)