### PR TITLE
Add kustomization.yaml for easy operator deployment

### DIFF
--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# If changing the namespace, also update the cluster_role_binding.yaml.
+namespace: default
+resources:
+- crds/core.observatorium.io_observatoria.yaml
+- cluster_role.yaml
+- cluster_role_binding.yaml
+- service_account.yaml
+- operator.yaml


### PR DESCRIPTION
This should make operator deployment easier using `kustomize`
I can update [the docs](https://github.com/observatorium/operator/blob/master/docs/deploy-operator.md#deploy-observatorium-crd-and-operator) after it is merged.

To deploy run: ` kustomize build manifests/ | kubectl apply -f -` in the repo root

