### PR TITLE
Use fixed locutus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ COPY . operator/
 COPY ./jsonnet/vendor/github.com/observatorium/deployments/components/ components/
 
 # Build
+WORKDIR /workspace/operator
 RUN GO111MODULE="on" go build github.com/brancz/locutus
 
 FROM alpine:3.10 as runner
 
 WORKDIR /
-COPY --from=builder /workspace/locutus /
+COPY --from=builder /workspace/operator/locutus /
 COPY --from=builder /workspace/operator/jsonnet /environments/operator
 COPY --from=builder /workspace/components/ /components/
 COPY --from=builder /workspace/operator/jsonnet/vendor/ /vendor/


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

Use the fixed locutus version in go.mod to build locutus rather than latest locutus.