### PR TITLE
Fix container-push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 jobs:
   build:
-    working_directory: /go/src/github.com/observatorium/deployments
+    working_directory: /go/src/github.com/observatorium/operator
     docker:
       - image: quay.io/coreos/jsonnet-ci
     steps:
@@ -25,7 +25,9 @@ jobs:
           path: /tmp/artifacts
 
   container-push:
-    machine: true
+    working_directory: /go/src/github.com/observatorium/operator
+    docker:
+      - image: quay.io/coreos/jsonnet-ci
     steps:
       - checkout
       - run: make jsonnet-vendor


### PR DESCRIPTION
https://quay.io/repository/observatorium/observatorium-operator?tag=latest&tab=tags the container was not updated for a  long time.

the problem is `flag provided but not defined: -mod`. we require use go 1.14+ to run the command.

I am not sure if it can fix https://github.com/observatorium/operator/issues/42 or not, because it requires to use the latest kube-thanos. this one can fix it - https://github.com/observatorium/operator/pull/41

Signed-off-by: clyang82 <chuyang@redhat.com>