### PR TITLE
fix container push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
 
   container-push:
     working_directory: /go/src/github.com/observatorium/operator
-    docker:
-      - image: quay.io/coreos/jsonnet-ci
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run: make jsonnet-vendor


### PR DESCRIPTION
Continue to fix the container push by using `machine` instead of `docker` in https://github.com/observatorium/operator/pull/43

Signed-off-by: clyang82 <chuyang@redhat.com>

/assign @squat 