### PR TITLE
.circleci: fix the container push job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       image: ubuntu-1604:201903-01
     steps:
       - checkout
-      - run: make jsonnet-vendor
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
           make container-push


### PR DESCRIPTION
This commit eliminates the step that vendors jsonnet from the container
push job, as this is causing problems with golang. A longer-term fix
would be to use a Docker image with the correct golang version expected
by the rest of the Makefile.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @clyang82 @observatorium/maintainers 