### PR TITLE
correct thanosReceiveController and store name

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -40,9 +40,9 @@ local operatorObs = obs {
       objectStorageConfig: cr.spec.objectStorageConfig.thanos,
     }),
 
-    store:: thanos.storeShards(obs.thanos.store.config {
-      image: if std.objectHas(cr.spec.store, 'image') then cr.spec.store.image else obs.thanos.store.config.image,
-      version: if std.objectHas(cr.spec.store, 'version') then cr.spec.store.version else obs.thanos.store.config.version,
+    stores:: thanos.storeShards(obs.thanos.stores.config {
+      image: if std.objectHas(cr.spec.store, 'image') then cr.spec.store.image else obs.thanos.stores.config.image,
+      version: if std.objectHas(cr.spec.store, 'version') then cr.spec.store.version else obs.thanos.stores.config.version,
       objectStorageConfig: cr.spec.objectStorageConfig.thanos,
       logLevel: 'info',
     }),

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -16,7 +16,7 @@ local operatorObs = obs {
       logLevel: 'info',
     }),
 
-    thanosReceiveController:: receiveController(obs.thanos.receiveController.config {
+    receiveController:: receiveController(obs.thanos.receiveController.config {
       image: if std.objectHas(cr.spec, 'thanosReceiveController') && std.objectHas(cr.spec.thanosReceiveController, 'image') then cr.spec.thanosReceiveController.image else obs.thanos.receiveController.config.image,
       version: if std.objectHas(cr.spec, 'thanosReceiveController') && std.objectHas(cr.spec.thanosReceiveController, 'version') then cr.spec.thanosReceiveController.version else obs.thanos.receiveController.config.version,
       hashrings: cr.spec.hashrings,


### PR DESCRIPTION
Should keep consistent with the name `receiveController` in https://github.com/observatorium/operator/blob/master/jsonnet/vendor/github.com/observatorium/deployments/components/thanos.libsonnet#L140
and the name `stores` in https://github.com/observatorium/operator/blob/master/jsonnet/vendor/github.com/observatorium/deployments/components/thanos.libsonnet#L207

Signed-off-by: clyang82 <chuyang@redhat.com>