### PR TITLE
Update ignoreDeletionMarksDelay based on deleteDelay

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -141,14 +141,10 @@ type StoreSpec struct {
 	// Compute Resources required by this container.
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
-<<<<<<< HEAD
 	// ServiceMonitor enables deploying a service monitor for the Thanos Stores.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
-	// Duration after which the blocks marked for deletion will be filtered out while fetching blocks
-=======
 	// Duration after which the blocks marked for deletion will be filtered out while fetching blocks.
->>>>>>> 045aa31 (Update api/v1alpha1/observatorium_types.go)
 	// +optional
 	IgnoreDeletionMarksDelay string `json:"ignoreDeletionMarksDelay,omitempty"`
 }
@@ -375,7 +371,7 @@ type CompactSpec struct {
 	// ServiceMonitor enables deploying a service monitor for the Thanos Compactors.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
-	// Time before a block marked for deletion is deleted from bucket
+	// Time before a block marked for deletion is deleted from object storage.
 	// +optional
 	DeleteDelay string `json:"deleteDelay,omitempty"`
 }

--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -141,10 +141,14 @@ type StoreSpec struct {
 	// Compute Resources required by this container.
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+<<<<<<< HEAD
 	// ServiceMonitor enables deploying a service monitor for the Thanos Stores.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
 	// Duration after which the blocks marked for deletion will be filtered out while fetching blocks
+=======
+	// Duration after which the blocks marked for deletion will be filtered out while fetching blocks.
+>>>>>>> 045aa31 (Update api/v1alpha1/observatorium_types.go)
 	// +optional
 	IgnoreDeletionMarksDelay string `json:"ignoreDeletionMarksDelay,omitempty"`
 }

--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -144,6 +144,9 @@ type StoreSpec struct {
 	// ServiceMonitor enables deploying a service monitor for the Thanos Stores.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
+	// Duration after which the blocks marked for deletion will be filtered out while fetching blocks
+	// +optional
+	IgnoreDeletionMarksDelay string `json:"ignoreDeletionMarksDelay,omitempty"`
 }
 
 // StoreCacheSpec describes configuration for Store Memcached
@@ -368,6 +371,9 @@ type CompactSpec struct {
 	// ServiceMonitor enables deploying a service monitor for the Thanos Compactors.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
+	// Time before a block marked for deletion is deleted from bucket
+	// +optional
+	DeleteDelay string `json:"deleteDelay,omitempty"`
 }
 
 type VolumeClaimTemplate struct {

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -32,9 +32,7 @@ local operatorObs = obs {
     } + if std.objectHas(cr.spec, 'rule') then cr.spec.rule else {},
 
     stores+:: {
-      local deleteDelay = if std.objectHas(cr.spec, 'compact') && std.objectHas(cr.spec.compact, 'deleteDelay') then cr.spec.compact.deleteDelay else obs.thanos.compact.config.deleteDelay,
       securityContext: if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else obs.thanos.stores.config.securityContext,
-      ignoreDeletionMarksDelay: std.parseInt(std.substr(deleteDelay, 0, std.length(deleteDelay)-1))/2 + std.substr(deleteDelay, std.length(deleteDelay)-1, std.length(deleteDelay)),
     } + if std.objectHas(cr.spec, 'store') then cr.spec.store else {},
 
     storeCache+:: (if std.objectHas(cr.spec, 'store') && std.objectHas(cr.spec.store, 'cache') then cr.spec.store.cache else {}) + {

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -32,7 +32,9 @@ local operatorObs = obs {
     } + if std.objectHas(cr.spec, 'rule') then cr.spec.rule else {},
 
     stores+:: {
+      local deleteDelay = if std.objectHas(cr.spec, 'compact') && std.objectHas(cr.spec.compact, 'deleteDelay') then cr.spec.compact.deleteDelay else obs.thanos.compact.config.deleteDelay,
       securityContext: if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else obs.thanos.stores.config.securityContext,
+      ignoreDeletionMarksDelay: std.parseInt(std.substr(deleteDelay, 0, std.length(deleteDelay)-1))/2 + std.substr(deleteDelay, std.length(deleteDelay)-1, std.length(deleteDelay)),
     } + if std.objectHas(cr.spec, 'store') then cr.spec.store else {},
 
     storeCache+:: (if std.objectHas(cr.spec, 'store') && std.objectHas(cr.spec.store, 'cache') then cr.spec.store.cache else {}) + {

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1069,6 +1069,10 @@ spec:
               compact:
                 description: Thanos CompactSpec
                 properties:
+                  deleteDelay:
+                    description: Time before a block marked for deletion is deleted
+                      from bucket
+                    type: string
                   enableDownsampling:
                     description: EnableDownsampling enables downsampling.
                     type: boolean
@@ -2390,6 +2394,10 @@ spec:
                         description: Version of Memcached image to be deployed.
                         type: string
                     type: object
+                  ignoreDeletionMarksDelay:
+                    description: Duration after which the blocks marked for deletion
+                      will be filtered out while fetching blocks
+                    type: string
                   image:
                     description: Thanos image
                     type: string

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1071,7 +1071,7 @@ spec:
                 properties:
                   deleteDelay:
                     description: Time before a block marked for deletion is deleted
-                      from bucket
+                      from object storage.
                     type: string
                   enableDownsampling:
                     description: EnableDownsampling enables downsampling.
@@ -2396,7 +2396,7 @@ spec:
                     type: object
                   ignoreDeletionMarksDelay:
                     description: Duration after which the blocks marked for deletion
-                      will be filtered out while fetching blocks
+                      will be filtered out while fetching blocks.
                     type: string
                   image:
                     description: Thanos image


### PR DESCRIPTION
Set `configure --ignore-deletion-marks-delay` to (delete-delay)/2 
Here is description from document:
> I can configure --ignore-deletion-marks-delay in store (Duration after which the blocks marked for deletion will be filtered out while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore blocks that are marked for deletion with some delay. This ensures store can still serve blocks that are meant to be deleted but do not have a replacement yet. If delete-delay duration is provided to compactor or bucket verify component, it will upload deletion-mark.json file to mark after what duration the block should be deleted rather than deleting the block straight away. If delete-delay is non-zero for compactor or bucket verify component, ignore-deletion-marks-delay should be set to (delete-delay)/2 so that blocks marked for deletion are filtered out while fetching blocks before being deleted from bucket. Default is 24h, half of the default value for --delete-delay on compactor)

Signed-off-by: clyang82 <chuyang@redhat.com>