### PR TITLE
Update alertmanagersURL to alertmanagersURLs

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -310,9 +310,9 @@ type RuleSpec struct {
 	// RulesConfig configures rules from the configmaps
 	// +optional
 	RulesConfig []RuleConfig `json:"rulesConfig,omitempty"`
-	// AlertmanagersURLs
+	// AlertmanagerURLs
 	// +optional
-	AlertmanagersURLs []string `json:"alertmanagersURLs,omitempty"`
+	AlertmanagerURLs []string `json:"alertmanagerURLs,omitempty"`
 	// ReloaderImage is an image of configmap reloader
 	// +optional
 	ReloaderImage string `json:"reloaderImage,omitempty"`

--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -310,9 +310,9 @@ type RuleSpec struct {
 	// RulesConfig configures rules from the configmaps
 	// +optional
 	RulesConfig []RuleConfig `json:"rulesConfig,omitempty"`
-	// AlertmanagersURL
+	// AlertmanagersURLs
 	// +optional
-	AlertmanagersURL []string `json:"alertmanagersURL,omitempty"`
+	AlertmanagersURLs []string `json:"alertmanagersURLs,omitempty"`
 	// ReloaderImage is an image of configmap reloader
 	// +optional
 	ReloaderImage string `json:"reloaderImage,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -516,8 +516,8 @@ func (in *RuleSpec) DeepCopyInto(out *RuleSpec) {
 		*out = make([]RuleConfig, len(*in))
 		copy(*out, *in)
 	}
-	if in.AlertmanagersURL != nil {
-		in, out := &in.AlertmanagersURL, &out.AlertmanagersURL
+	if in.AlertmanagersURLs != nil {
+		in, out := &in.AlertmanagersURLs, &out.AlertmanagersURLs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -516,8 +516,8 @@ func (in *RuleSpec) DeepCopyInto(out *RuleSpec) {
 		*out = make([]RuleConfig, len(*in))
 		copy(*out, *in)
 	}
-	if in.AlertmanagersURLs != nil {
-		in, out := &in.AlertmanagersURLs, &out.AlertmanagersURLs
+	if in.AlertmanagerURLs != nil {
+		in, out := &in.AlertmanagerURLs, &out.AlertmanagerURLs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -28,6 +28,7 @@ local operatorObs = obs {
 
     rule+:: {
       securityContext: if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else obs.thanos.rule.config.securityContext,
+      alertmanagersURLs: if std.objectHas(cr.spec, 'rule') && std.objectHas(cr.spec.rule, 'alertmanagerURLs') then cr.spec.rule.alertmanagerURLs else obs.thanos.rule.config.alertmanagersURLs,
     } + if std.objectHas(cr.spec, 'rule') then cr.spec.rule else {},
 
     stores+:: {

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1084,8 +1084,8 @@ spec:
               rule:
                 description: Thanos RulerSpec
                 properties:
-                  alertmanagersURL:
-                    description: AlertmanagersURL
+                  alertmanagersURLs:
+                    description: AlertmanagersURLs
                     items:
                       type: string
                     type: array

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1084,8 +1084,8 @@ spec:
               rule:
                 description: Thanos RulerSpec
                 properties:
-                  alertmanagersURLs:
-                    description: AlertmanagersURLs
+                  alertmanagerURLs:
+                    description: AlertmanagerURLs
                     items:
                       type: string
                     type: array


### PR DESCRIPTION
the value was changed in this PR https://github.com/thanos-io/kube-thanos/pull/164 from `alertmanagersURL` to `alertmanagersURLs`. we need to update operator to make it work.

cc @metalmatze 


Signed-off-by: clyang82 <chuyang@redhat.com>