### PR TITLE
Updating links to Minio yaml examples

### DIFF
--- a/docs/deploy-operator.md
+++ b/docs/deploy-operator.md
@@ -29,10 +29,10 @@ For **testing purposes** you may use [minio](https://github.com/minio/minio) as 
 
 ```shell
 kubectl create namespace observatorium-minio
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-secret-thanos.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-pvc.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-deployment.yaml
-kubectl apply -f https://raw.githubusercontent.com/observatorium/deployments/master/environments/dev/manifests/minio-service.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/observatorium/main/configuration/examples/dev/manifests/minio-secret-thanos.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/observatorium/main/configuration/examples/dev/manifests/minio-pvc.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/observatorium/main/configuration/examples/dev/manifests/minio-deployment.yaml
+kubectl apply -f https://raw.githubusercontent.com/observatorium/observatorium/main/configuration/examples/dev/manifests/minio-service.yaml
 ```
 
 ### Deployment


### PR DESCRIPTION
The files specified in the 'S3 storage endpoint and secret' section have been moved.
Updated the URLs to link to the active files.