### PR TITLE
fix#84: reference serviceAccount in namespace observatorium-operator

### DIFF
--- a/manifests/cluster_role_binding.yaml
+++ b/manifests/cluster_role_binding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: observatorium-operator
-  namespace: default
+  namespace: observatorium-operator


### PR DESCRIPTION


fix #84